### PR TITLE
Closes spinscale/dropwizard-jobs/#18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,18 +63,19 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                    <encoding>UTF-8</encoding>
-                </configuration>
-            </plugin>
-        </plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.2</version>
+					<configuration>
+						<source>1.8</source>
+						<target>1.7</target>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
     </build>
 
     <modules>


### PR DESCRIPTION
A few things:

* `build/plugins` should be `build/pluginManagement/plugins`.
* removing unnecessary UTF-8 config in compiler plugin declaration
* keeping `target` on 1.7 (compatibility) but `source` on 1.8