### PR TITLE
prepared for public repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Fork #
+
+This is a fork used simply to publish dropwizard-jobs to a public maven repository.
+
+The repository is available at https://nexus.vanntett.net/content/repositories/dropwizard-jobs/
+
+I will keep this repository updated as needed. I have also reached out to the original dev to grant him access to publish to the repository if wanted.
+
 # Dropwizard quartz integration
 
 This plugin integrates the [quartz scheduler](http://quartz-scheduler.org/) with dropwizard and allows you to easily create background jobs, which are not bound to the HTTP request-response cycle.

--- a/dropwizard-jobs-guice/README.md
+++ b/dropwizard-jobs-guice/README.md
@@ -1,3 +1,11 @@
+# Fork #
+
+This is a fork used simply to publish dropwizard-jobs to a public maven repository.
+
+The repository is available at https://nexus.vanntett.net/content/repositories/dropwizard-jobs/
+
+I will keep this repository updated as needed. I have also reached out to the original dev to grant him access to publish to the repository if wanted.
+
 # Dropwizard quartz integration with Guice
 
 This is a extension for [dropwizard-jobs](https://github.com/spinscale/dropwizard-jobs) to use

--- a/pom.xml
+++ b/pom.xml
@@ -99,4 +99,11 @@
         <module>dropwizard-jobs-spring</module>
     </modules>
 
+     <distributionManagement>
+	<repository>
+            <id>dropwizard-jobs</id>
+            <url>https://nexus.vanntett.net/content/repositories/dropwizard-jobs</url>
+        </repository>
+     </distributionManagement>
+
 </project>


### PR DESCRIPTION
I simply loathe not having public available maven repositories for libraries I use. I therefore added a repository for dropwizard-jobs in my publicly available nexus. If you wish I can give you an account with push access so you can push any updates to the repository. Let me know.