### PR TITLE
Delaystart annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ public class EveryTestJob extends Job {
 }
 ```
 
+The <code>@DelayStart</code> annotation can be used in conjunction with @Every to delay the start of the job. Without this, all the @Every jobs start up at the same time when the scheduler starts.
+
+```java
+@DelayStart("5s")
+@Every("1s")
+public class EveryTestJobWithDelayedStart extends Job {
+  @Override
+  public void doJob() {
+    // logic run every time and time again
+  }
+}
+```
+
 The <code>@On</code> annotation allows one to use cron-like expressions for complex time settings. You can read more about possible cron expressions at http://quartz-scheduler.org/documentation/quartz-2.1.x/tutorials/tutorial-lesson-06
 
 This expression allows you to run a job every 15 seconds and could possibly also be run via a @Every annotation.

--- a/dropwizard-jobs-core/pom.xml
+++ b/dropwizard-jobs-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.spinscale</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
     <artifactId>dropwizard-jobs-core</artifactId>
     <name>dropwizard-jobs-core</name>

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/annotations/DelayStart.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/annotations/DelayStart.java
@@ -1,0 +1,19 @@
+package de.spinscale.dropwizard.jobs.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Delay the start of a job which has the {@link Every @Every} annotation. Without a delay the job will
+ * start immediately.
+ * 
+ * @author Martin Charlesworth
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DelayStart {
+    String value();
+}

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobWithDelay.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobWithDelay.java
@@ -1,0 +1,21 @@
+package de.spinscale.dropwizard.jobs;
+
+import java.util.Date;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import de.spinscale.dropwizard.jobs.annotations.DelayStart;
+import de.spinscale.dropwizard.jobs.annotations.Every;
+
+@DelayStart("3s")
+@Every("1s")
+public class EveryTestJobWithDelay extends Job {
+
+    public static List<String> results = Lists.newArrayList();
+
+    @Override
+    public void doJob() {
+        results.add(new Date().toString());
+    }
+}

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
@@ -2,6 +2,7 @@ package de.spinscale.dropwizard.jobs;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.hasSize;
 
 import org.junit.After;
@@ -11,6 +12,7 @@ import org.junit.Test;
 public class JobManagerTest {
 
     JobManager jobManager;
+    private boolean stopped;
 
     @Before
     public void setUp() throws Exception {
@@ -19,6 +21,9 @@ public class JobManagerTest {
 
     @After
     public void tearDown() throws Exception {
+    	if (!stopped) {
+    		jobManager.stop();
+    	}
         jobManager = null;
     }
 
@@ -35,6 +40,7 @@ public class JobManagerTest {
         ApplicationStopTestJob.results.clear();
         jobManager.start();
         jobManager.stop();
+        stopped = true;
         assertThat(ApplicationStopTestJob.results, hasSize(1));
     }
 
@@ -53,4 +59,15 @@ public class JobManagerTest {
         Thread.sleep(5000);
         assertThat(EveryTestJob.results, hasSize(greaterThan(5)));
     }
+    
+    @Test
+    public void jobsWithEveryAnnotationAndDelayStartShouldWaitToBeExecuted() throws Exception {
+        EveryTestJobWithDelay.results.clear();
+        jobManager.start();
+        Thread.sleep(2500);
+        assertThat(EveryTestJobWithDelay.results, hasSize(0));
+        Thread.sleep(2500);
+        assertThat(EveryTestJobWithDelay.results, hasSize(lessThan(4)));
+    }
+
 }

--- a/dropwizard-jobs-guice/pom.xml
+++ b/dropwizard-jobs-guice/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
     <artifactId>dropwizard-jobs-guice</artifactId>
     <name>dropwizard-jobs-guice</name>

--- a/dropwizard-jobs-spring/pom.xml
+++ b/dropwizard-jobs-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
     <artifactId>dropwizard-jobs-spring</artifactId>
     <name>dropwizard-jobs-spring</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.spinscale</groupId>
 	<artifactId>dropwizard-jobs</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 	<packaging>pom</packaging>
 
 	<name>dropwizard-jobs</name>
@@ -14,7 +14,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<dropwizard.version>0.7.1</dropwizard.version>
+		<dropwizard.version>0.8.4</dropwizard.version>
 		<spring.version>4.0.5.RELEASE</spring.version>
 		<guice.version>4.0-beta5</guice.version>
 		<quartz.version>2.2.1</quartz.version>
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
-			<version>0.9.8</version>
+			<version>0.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Added @DelayStart annotation to delay the start of @Every jobs. I didn't want all my jobs to start up the moment the scheduler starts, and this provides a way to do it. I also upped dropwizard to 0.8.4.