### PR TITLE
Enhance Logging of Scheduled Jobs

### DIFF
--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
@@ -1,13 +1,11 @@
 package de.spinscale.dropwizard.jobs;
 
-import com.google.common.collect.Sets;
-import de.spinscale.dropwizard.jobs.annotations.DelayStart;
-import de.spinscale.dropwizard.jobs.annotations.Every;
-import de.spinscale.dropwizard.jobs.annotations.On;
-import de.spinscale.dropwizard.jobs.annotations.OnApplicationStart;
-import de.spinscale.dropwizard.jobs.annotations.OnApplicationStop;
-import de.spinscale.dropwizard.jobs.parser.TimeParserUtil;
-import io.dropwizard.lifecycle.Managed;
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
 import org.joda.time.DateTime;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.JobBuilder;
@@ -21,11 +19,15 @@ import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.annotation.Annotation;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import com.google.common.collect.Sets;
+
+import de.spinscale.dropwizard.jobs.annotations.DelayStart;
+import de.spinscale.dropwizard.jobs.annotations.Every;
+import de.spinscale.dropwizard.jobs.annotations.On;
+import de.spinscale.dropwizard.jobs.annotations.OnApplicationStart;
+import de.spinscale.dropwizard.jobs.annotations.OnApplicationStop;
+import de.spinscale.dropwizard.jobs.parser.TimeParserUtil;
+import io.dropwizard.lifecycle.Managed;
 
 public class JobManager implements Managed {
 


### PR DESCRIPTION
I thought it would be nice to have clearer information on the scheduling of configured jobs when Dropwizard starts up. I like the way Dropwizard logs configured JAX-RS resources, so I mimicked that.

Scheduled jobs are now more prominent in logs and they appear along with scheduling information, for example:

```
15:19:12.141 [main] INFO  d.s.dropwizard.jobs.JobManager - Jobs to run on application start:

    de.spinscale.dropwizard.jobs.ApplicationStartTestJob

15:19:12.143 [main] INFO  d.s.dropwizard.jobs.JobManager - Jobs with @Every annotation:

    1s      de.spinscale.dropwizard.jobs.EveryTestJobWithDelay (3s delay)
    1s      de.spinscale.dropwizard.jobs.EveryTestJob

15:19:12.144 [main] INFO  d.s.dropwizard.jobs.JobManager - Jobs with @On annotation:

    0/1 * * * * ?  de.spinscale.dropwizard.jobs.OnTestJob
```

If there are no jobs for a particular category:

```
15:19:12.141 [main] INFO  d.s.dropwizard.jobs.JobManager - Jobs to run on application start:

    NONE
```