### PR TITLE
Upgrade to Dropwizard 1.0.0

### DIFF
--- a/dropwizard-jobs-core/pom.xml
+++ b/dropwizard-jobs-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.spinscale</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.1</version>
     </parent>
     <artifactId>dropwizard-jobs-core</artifactId>
     <name>dropwizard-jobs-core</name>

--- a/dropwizard-jobs-guice/pom.xml
+++ b/dropwizard-jobs-guice/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.1</version>
     </parent>
     <artifactId>dropwizard-jobs-guice</artifactId>
     <name>dropwizard-jobs-guice</name>

--- a/dropwizard-jobs-spring/pom.xml
+++ b/dropwizard-jobs-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.1</version>
     </parent>
     <artifactId>dropwizard-jobs-spring</artifactId>
     <name>dropwizard-jobs-spring</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.spinscale</groupId>
 	<artifactId>dropwizard-jobs</artifactId>
-	<version>1.0.2</version>
+	<version>1.1.0</version>
 	<packaging>pom</packaging>
 
 	<name>dropwizard-jobs</name>
@@ -15,9 +15,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<dropwizard.version>0.8.4</dropwizard.version>
-		<spring.version>4.0.5.RELEASE</spring.version>
-		<guice.version>4.0-beta5</guice.version>
-		<quartz.version>2.2.1</quartz.version>
+		<spring.version>4.2.6.RELEASE</spring.version>
+		<guice.version>4.0</guice.version>
+		<quartz.version>2.2.3</quartz.version>
 	</properties>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<dropwizard.version>0.8.4</dropwizard.version>
+		<dropwizard.version>0.9.2</dropwizard.version>
 		<spring.version>4.2.6.RELEASE</spring.version>
 		<guice.version>4.0</guice.version>
 		<quartz.version>2.2.3</quartz.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.spinscale</groupId>
 	<artifactId>dropwizard-jobs</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<packaging>pom</packaging>
 
 	<name>dropwizard-jobs</name>
@@ -14,7 +14,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<dropwizard.version>0.9.2</dropwizard.version>
+		<dropwizard.version>1.0.0</dropwizard.version>
 		<spring.version>4.2.6.RELEASE</spring.version>
 		<guice.version>4.0</guice.version>
 		<quartz.version>2.2.3</quartz.version>


### PR DESCRIPTION
This is based on @hakandilek's work in #33. It also bumps the version to 1.1.1 — these were inconsistent between the parent and modules POMs, which caused the build to fail.