### PR TITLE
Major refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 2.0.0
+
+* The `groupId` has been renamed to `de.spinscale.dropwizard`
+* Removed any reflection based code in the code base, along with the reflections library
+* The above also means, every job has to be added manually to the JobsBundle - no more autodetection
+* The above also means, that wiring for guice/spring has to happen - constructor injection is encouraged now
+* Allowed jobs to have arbitrary constructors
+

--- a/dropwizard-jobs-core/pom.xml
+++ b/dropwizard-jobs-core/pom.xml
@@ -2,9 +2,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>de.spinscale</groupId>
+        <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>dropwizard-jobs-core</artifactId>
     <name>dropwizard-jobs-core</name>

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/DropwizardJobFactory.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/DropwizardJobFactory.java
@@ -1,0 +1,28 @@
+package de.spinscale.dropwizard.jobs;
+
+import org.quartz.Job;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.spi.JobFactory;
+import org.quartz.spi.TriggerFiredBundle;
+
+class DropwizardJobFactory implements JobFactory {
+
+    private final Job[] jobs;
+
+    DropwizardJobFactory(Job ... jobs) {
+        this.jobs = jobs;
+    }
+
+    @Override
+    public Job newJob(TriggerFiredBundle bundle, Scheduler scheduler) throws SchedulerException {
+        JobDetail jobDetail = bundle.getJobDetail();
+        for (Job job : jobs) {
+            if (job.getClass().equals(jobDetail.getJobClass())) {
+                return job;
+            }
+        }
+        return null;
+    }
+}

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/Job.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/Job.java
@@ -1,16 +1,16 @@
 package de.spinscale.dropwizard.jobs;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Timer.Context;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import static com.codahale.metrics.MetricRegistry.name;
 
 public abstract class Job implements org.quartz.Job {
+
     public static final String DROPWIZARD_JOBS_KEY = "dropwizard-jobs";
 
     private final Timer timer;

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobConfiguration.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobConfiguration.java
@@ -1,0 +1,10 @@
+package de.spinscale.dropwizard.jobs;
+
+import java.util.Collections;
+import java.util.Map;
+
+public interface JobConfiguration {
+    default Map<String, String> getJobs() {
+        return Collections.emptyMap();
+    }
+}

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobsBundle.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobsBundle.java
@@ -1,34 +1,29 @@
 package de.spinscale.dropwizard.jobs;
 
 import com.codahale.metrics.SharedMetricRegistries;
-
-import io.dropwizard.Bundle;
+import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
-public class JobsBundle implements Bundle {
+public class JobsBundle implements ConfiguredBundle<JobConfiguration> {
 
-    protected String scanURL = null;
+    private final Job[] jobs;
+
+    public JobsBundle(Job ... jobs) {
+        this.jobs = jobs;
+    }
+
+    @Override
+    public void run(JobConfiguration configuration, Environment environment) throws Exception {
+        JobManager jobManager = new JobManager(jobs);
+        jobManager.configure(configuration);
+        environment.lifecycle().manage(jobManager);
+    }
 
     @Override
     public void initialize(Bootstrap<?> bootstrap) {
         // add shared metrics registry to be used by Jobs, since defaultRegistry
         // has been removed
-        SharedMetricRegistries.add(Job.DROPWIZARD_JOBS_KEY,
-                bootstrap.getMetricRegistry());
+        SharedMetricRegistries.add(Job.DROPWIZARD_JOBS_KEY, bootstrap.getMetricRegistry());
     }
-
-    public JobsBundle() {
-    }
-
-    public JobsBundle(String scanURL) {
-        this.scanURL = scanURL;
-    }
-
-    @Override
-    public void run(Environment environment) {
-        JobManager jobManager = new JobManager(scanURL);
-        environment.lifecycle().manage(jobManager);
-    }
-
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/AbstractJob.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/AbstractJob.java
@@ -1,0 +1,21 @@
+package de.spinscale.dropwizard.jobs;
+
+import java.util.concurrent.CountDownLatch;
+
+public abstract class AbstractJob extends Job {
+
+    private final CountDownLatch latch;
+
+    public AbstractJob(int count) {
+        latch = new CountDownLatch(count);
+    }
+
+    @Override
+    public void doJob() {
+        latch.countDown();
+    }
+
+    public CountDownLatch latch() {
+        return latch;
+    }
+}

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
@@ -2,15 +2,10 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.OnApplicationStart;
 
-import java.util.concurrent.CountDownLatch;
-
 @OnApplicationStart
-public class ApplicationStartTestJob extends Job {
+public class ApplicationStartTestJob extends AbstractJob {
 
-    static final CountDownLatch latch = new CountDownLatch(1);
-
-    @Override
-    public void doJob() {
-        latch.countDown();
+    public ApplicationStartTestJob() {
+        super(1);
     }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
@@ -2,15 +2,15 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.OnApplicationStop;
 
-import java.util.concurrent.CountDownLatch;
-
 @OnApplicationStop
-public class ApplicationStopTestJob extends Job {
+public class ApplicationStopTestJob extends AbstractJob {
 
-    static final CountDownLatch latch = new CountDownLatch(1);
+    public ApplicationStopTestJob() {
+        super(1);
+    }
 
     @Override
     public void doJob() {
-        latch.countDown();
+        super.doJob();
     }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
@@ -2,15 +2,10 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
-import java.util.concurrent.CountDownLatch;
-
 @Every("10ms")
-public class EveryTestJob extends Job {
+public class EveryTestJob extends AbstractJob {
 
-    static final CountDownLatch latch = new CountDownLatch(5);
-
-    @Override
-    public void doJob() {
-        latch.countDown();
+    public EveryTestJob() {
+        super(5);
     }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobAlternativeConfiguration.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobAlternativeConfiguration.java
@@ -2,15 +2,10 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
-import java.util.concurrent.CountDownLatch;
-
 @Every("${testJob}")
-public class EveryTestJobAlternativeConfiguration extends Job {
+public class EveryTestJobAlternativeConfiguration extends AbstractJob {
 
-    static final CountDownLatch latch = new CountDownLatch(5);
-
-    @Override
-    public void doJob() {
-        latch.countDown();
+    public EveryTestJobAlternativeConfiguration() {
+        super(5);
     }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobWithDelay.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobWithDelay.java
@@ -3,16 +3,11 @@ package de.spinscale.dropwizard.jobs;
 import de.spinscale.dropwizard.jobs.annotations.DelayStart;
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
-import java.util.concurrent.CountDownLatch;
-
 @DelayStart("1s")
-@Every("50ms")
-public class EveryTestJobWithDelay extends Job {
+@Every("10ms")
+public class EveryTestJobWithDelay extends AbstractJob {
 
-    static final CountDownLatch latch = new CountDownLatch(5);
-
-    @Override
-    public void doJob() {
-        latch.countDown();
+    public EveryTestJobWithDelay() {
+        super(5);
     }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobWithJobName.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobWithJobName.java
@@ -1,19 +1,11 @@
 package de.spinscale.dropwizard.jobs;
 
-import java.util.Date;
-import java.util.List;
-
-import com.google.common.collect.Lists;
-
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
-@Every(value = "1s", jobName = "FooJob")
-public class EveryTestJobWithJobName extends Job {
+@Every(value = "10ms", jobName = "FooJob")
+public class EveryTestJobWithJobName extends AbstractJob {
 
-    public static List<String> results = Lists.newArrayList();
-
-    @Override
-    public void doJob() {
-        results.add(new Date().toString());
+    public EveryTestJobWithJobName() {
+        super(5);
     }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
@@ -1,34 +1,37 @@
 package de.spinscale.dropwizard.jobs;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertTrue;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
+import de.spinscale.dropwizard.jobs.annotations.Every;
+import de.spinscale.dropwizard.jobs.annotations.On;
+import io.dropwizard.Configuration;
 import org.hamcrest.core.IsEqual;
 import org.junit.Before;
 import org.junit.Test;
 import org.quartz.JobKey;
 
-import de.spinscale.dropwizard.jobs.annotations.Every;
-import de.spinscale.dropwizard.jobs.annotations.On;
-import io.dropwizard.Configuration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
 
 public class JobManagerTest {
 
     private JobManager jobManager = new JobManager();
+    private ApplicationStartTestJob startTestJob = new ApplicationStartTestJob();
+    private OnTestJob onTestJob = new OnTestJob();
+    private OnTestJobWithJobName onTestJobWithJobName = new OnTestJobWithJobName();
+    private EveryTestJob everyTestJob = new EveryTestJob();
+    private EveryTestJobWithDelay everyTestJobWithDelay = new EveryTestJobWithDelay();
+    private EveryTestJobAlternativeConfiguration everyTestJobAlternativeConfiguration = new EveryTestJobAlternativeConfiguration();
+    private EveryTestJobWithJobName everyTestJobWithJobName = new EveryTestJobWithJobName();
+    private ApplicationStopTestJob applicationStopTestJob = new ApplicationStopTestJob();
 
     @Before
     public void ensureLatchesAreUntouched() {
-        assertThat(ApplicationStartTestJob.latch.getCount(), is(1L));
-        assertThat(OnTestJob.latch.getCount(), is(2L));
-        assertThat(EveryTestJob.latch.getCount(), is(5L));
-        assertThat(EveryTestJobWithDelay.latch.getCount(), is(5L));
-        assertThat(EveryTestJobAlternativeConfiguration.latch.getCount(), is(5L));
-        assertThat(ApplicationStopTestJob.latch.getCount(), is(1L));
+        jobManager = new JobManager(startTestJob, onTestJob, onTestJobWithJobName, everyTestJob, everyTestJobWithJobName,
+                everyTestJobWithDelay, everyTestJobAlternativeConfiguration, applicationStopTestJob);
     }
 
     @Test
@@ -63,19 +66,20 @@ public class JobManagerTest {
         assertTrue(jobManager.scheduler.checkExists(JobKey.jobKey(jobName)));
         assertThat(jobManager.scheduler.getTriggersOfJob(JobKey.jobKey(jobName)).size(), IsEqual.equalTo(1));
 
-        assertThat(EveryTestJobWithDelay.latch.await(800, TimeUnit.MILLISECONDS), is(false));
-        assertThat(ApplicationStartTestJob.latch.await(1, TimeUnit.SECONDS), is(true));
-        assertThat(EveryTestJobAlternativeConfiguration.latch.await(1, TimeUnit.SECONDS), is(true));
-        assertThat(EveryTestJobWithDelay.latch.await(2, TimeUnit.SECONDS), is(true));
-        assertThat(EveryTestJob.latch.await(1, TimeUnit.SECONDS), is(true));
-        assertThat(OnTestJob.latch.await(5, TimeUnit.SECONDS), is(true));
+        assertThat(everyTestJobWithDelay.latch().await(100, TimeUnit.MILLISECONDS), is(false));
+        assertThat(everyTestJobWithJobName.latch().await(1, TimeUnit.SECONDS), is(true));
+        assertThat(everyTestJobAlternativeConfiguration.latch().await(1, TimeUnit.SECONDS), is(true));
+        assertThat(everyTestJob.latch().await(1, TimeUnit.SECONDS), is(true));
+
+        assertThat(everyTestJobWithDelay.latch().await(2, TimeUnit.SECONDS), is(true));
+        assertThat(onTestJob.latch().await(2, TimeUnit.SECONDS), is(true));
 
         jobManager.stop();
 
-        assertThat(ApplicationStopTestJob.latch.await(2, TimeUnit.SECONDS), is(true));
+        assertThat(applicationStopTestJob.latch().await(2, TimeUnit.SECONDS), is(true));
     }
 
-    private static class TestConfig extends Configuration {
+    private static class TestConfig extends Configuration implements JobConfiguration {
         private Map<String, String> jobs = new HashMap<>();
 
         public Map<String, String> getJobs() {

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobsBundleTest.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobsBundleTest.java
@@ -1,16 +1,17 @@
 package de.spinscale.dropwizard.jobs;
 
+import io.dropwizard.Configuration;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.Environment;
-
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 public class JobsBundleTest {
 
@@ -18,9 +19,9 @@ public class JobsBundleTest {
     private final LifecycleEnvironment applicationContext = mock(LifecycleEnvironment.class);
 
     @Test
-    public void assertJobsBundleIsWorking() {
+    public void assertJobsBundleIsWorking() throws Exception {
         when(environment.lifecycle()).thenReturn(applicationContext);
-        new JobsBundle().run(environment);
+        new JobsBundle().run(new MyConfiguration(), environment);
 
         final ArgumentCaptor<JobManager> captor = ArgumentCaptor.forClass(JobManager.class);
         verify(applicationContext).manage(captor.capture());
@@ -28,4 +29,6 @@ public class JobsBundleTest {
         JobManager jobManager = captor.getValue();
         assertThat(jobManager, is(notNullValue()));
     }
+
+    private static class MyConfiguration extends Configuration implements JobConfiguration {}
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
@@ -2,15 +2,10 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.On;
 
-import java.util.concurrent.CountDownLatch;
-
 @On("0/1 * * * * ?")
-public class OnTestJob extends Job {
+public class OnTestJob extends AbstractJob {
 
-    static final CountDownLatch latch = new CountDownLatch(2);
-
-    @Override
-    public void doJob() {
-        latch.countDown();
+    public OnTestJob() {
+        super(1);
     }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/OnTestJobWithJobName.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/OnTestJobWithJobName.java
@@ -1,19 +1,11 @@
 package de.spinscale.dropwizard.jobs;
 
-import java.util.Date;
-import java.util.List;
-
-import com.google.common.collect.Lists;
-
 import de.spinscale.dropwizard.jobs.annotations.On;
 
 @On(value = "0/1 * * * * ?", jobName = "BarJob")
-public class OnTestJobWithJobName extends Job {
+public class OnTestJobWithJobName extends AbstractJob {
 
-    public static List<String> results = Lists.newArrayList();
-
-    @Override
-    public void doJob() {
-        results.add(new Date().toString());
+    public OnTestJobWithJobName() {
+        super(1);
     }
 }

--- a/dropwizard-jobs-guice/pom.xml
+++ b/dropwizard-jobs-guice/pom.xml
@@ -1,15 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>de.spinscale</groupId>
+        <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>dropwizard-jobs-guice</artifactId>
     <name>dropwizard-jobs-guice</name>
     <dependencies>
         <dependency>
-            <groupId>de.spinscale</groupId>
+            <groupId>de.spinscale.dropwizard</groupId>
             <artifactId>dropwizard-jobs-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/dropwizard-jobs-guice/src/main/java/de/spinscale/dropwizard/jobs/GuiceJobFactory.java
+++ b/dropwizard-jobs-guice/src/main/java/de/spinscale/dropwizard/jobs/GuiceJobFactory.java
@@ -9,9 +9,6 @@ import org.quartz.SchedulerException;
 import org.quartz.spi.JobFactory;
 import org.quartz.spi.TriggerFiredBundle;
 
-/**
- * Created by yun on 17/03/14.
- */
 public class GuiceJobFactory implements JobFactory {
 
     private Injector injector;

--- a/dropwizard-jobs-guice/src/main/java/de/spinscale/dropwizard/jobs/GuiceJobsBundle.java
+++ b/dropwizard-jobs-guice/src/main/java/de/spinscale/dropwizard/jobs/GuiceJobsBundle.java
@@ -1,31 +1,19 @@
 package de.spinscale.dropwizard.jobs;
 
 import com.google.inject.Injector;
-import de.spinscale.dropwizard.jobs.JobsBundle;
-import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
 
 public class GuiceJobsBundle extends JobsBundle {
-    Injector injector;
+
     private GuiceJobManager guiceJobsManager;
     
     public GuiceJobsBundle(Injector injector) {
-        this("", injector);
-    }
-
-    public GuiceJobsBundle(String scanUrl, Injector injector) {
-        super(scanUrl);
-        this.injector = injector;
-        guiceJobsManager = new GuiceJobManager(scanURL, injector);
+        guiceJobsManager = new GuiceJobManager(injector);
     }
 
     @Override
-    public void run(Environment environment) {
+    public void run(JobConfiguration configuration, Environment environment) throws Exception {
+        guiceJobsManager.configure(configuration);
         environment.lifecycle().manage(guiceJobsManager);
     }
-    
-    public void configure(Configuration config) {
-    	guiceJobsManager.configure(config);
-    }
-
 }

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 @OnApplicationStart
 public class ApplicationStartTestJob extends Job {
 
-    static final CountDownLatch latch = new CountDownLatch(1);
+    final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 @OnApplicationStop
 public class ApplicationStopTestJob extends Job {
 
-    static final CountDownLatch latch = new CountDownLatch(1);
+    final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/DependencyTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/DependencyTestJob.java
@@ -8,10 +8,13 @@ import java.util.concurrent.CountDownLatch;
 @Every("100ms")
 public class DependencyTestJob extends Job {
 
-    @Inject
+    final CountDownLatch latch = new CountDownLatch(5);
     private Dependency dependency;
 
-    static final CountDownLatch latch = new CountDownLatch(5);
+    @Inject
+    public DependencyTestJob(Dependency dependency) {
+        this.dependency = dependency;
+    }
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 @Every("100ms")
 public class EveryTestJob extends Job {
 
-    static final CountDownLatch latch = new CountDownLatch(5);
+    final CountDownLatch latch = new CountDownLatch(5);
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/GuiceJobsBundleTest.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/GuiceJobsBundleTest.java
@@ -1,13 +1,12 @@
 package de.spinscale.dropwizard.jobs;
 
-import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.Environment;
-
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.dropwizard.Configuration;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -22,11 +21,11 @@ public class GuiceJobsBundleTest {
     private final LifecycleEnvironment applicationContext = mock(LifecycleEnvironment.class);
 
     @Test
-    public void assertJobsBundleIsWorking() {
+    public void assertJobsBundleIsWorking() throws Exception {
         Injector injector = Guice.createInjector();
 
         when(environment.lifecycle()).thenReturn(applicationContext);
-        new GuiceJobsBundle(injector).run(environment);
+        new GuiceJobsBundle(injector).run(new MyConfiguration(), environment);
 
         final ArgumentCaptor<JobManager> jobManagerCaptor = ArgumentCaptor.forClass(JobManager.class);
         verify(applicationContext).manage(jobManagerCaptor.capture());
@@ -34,4 +33,6 @@ public class GuiceJobsBundleTest {
         JobManager jobManager = jobManagerCaptor.getValue();
         assertThat(jobManager, is(notNullValue()));
     }
+
+    private static class MyConfiguration extends Configuration implements JobConfiguration {}
 }

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 @On("0/1 * * * * ?")
 public class OnTestJob extends Job {
 
-    static final CountDownLatch latch = new CountDownLatch(2);
+    final CountDownLatch latch = new CountDownLatch(2);
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-spring/pom.xml
+++ b/dropwizard-jobs-spring/pom.xml
@@ -1,15 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>de.spinscale</groupId>
+        <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>dropwizard-jobs-spring</artifactId>
     <name>dropwizard-jobs-spring</name>
     <dependencies>
         <dependency>
-            <groupId>de.spinscale</groupId>
+            <groupId>de.spinscale.dropwizard</groupId>
             <artifactId>dropwizard-jobs-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/dropwizard-jobs-spring/src/main/java/de/spinscale/dropwizard/jobs/SpringJobManager.java
+++ b/dropwizard-jobs-spring/src/main/java/de/spinscale/dropwizard/jobs/SpringJobManager.java
@@ -1,31 +1,19 @@
 package de.spinscale.dropwizard.jobs;
 
-import de.spinscale.dropwizard.jobs.JobManager;
-
-import org.quartz.impl.StdSchedulerFactory;
-import org.reflections.Reflections;
+import org.quartz.spi.JobFactory;
 import org.springframework.context.ApplicationContext;
 
 public class SpringJobManager extends JobManager {
 
     protected SpringJobFactory jobFactory;
 
-    public SpringJobManager(String scanUrl, ApplicationContext context) {
-        reflections = new Reflections(scanUrl);
+    public SpringJobManager(ApplicationContext context) {
+        super(context.getBeansOfType(Job.class).values().toArray(new Job[] {}));
         jobFactory = new SpringJobFactory(context);
     }
 
-    public SpringJobManager(ApplicationContext context) {
-        this("", context);
-    }
-
     @Override
-    public void start() throws Exception {
-        scheduler = StdSchedulerFactory.getDefaultScheduler();
-        scheduler.setJobFactory(jobFactory);
-        scheduler.start();
-
-        scheduleAllJobs();
+    protected JobFactory getJobFactory() {
+        return jobFactory;
     }
-
 }

--- a/dropwizard-jobs-spring/src/main/java/de/spinscale/dropwizard/jobs/SpringJobsBundle.java
+++ b/dropwizard-jobs-spring/src/main/java/de/spinscale/dropwizard/jobs/SpringJobsBundle.java
@@ -1,26 +1,21 @@
 package de.spinscale.dropwizard.jobs;
 
-import org.springframework.context.ApplicationContext;
-
-import de.spinscale.dropwizard.jobs.JobsBundle;
 import io.dropwizard.setup.Environment;
+import org.springframework.context.ApplicationContext;
 
 public class SpringJobsBundle extends JobsBundle {
 
     private ApplicationContext context;
 
     public SpringJobsBundle(ApplicationContext context) {
-        this("", context);
-    }
-
-    public SpringJobsBundle(String scanUrl, ApplicationContext context) {
-        super(scanUrl);
         this.context = context;
     }
 
     @Override
-    public void run(Environment environment) {
-        environment.lifecycle().manage(new SpringJobManager(scanURL, context));
+    public void run(JobConfiguration configuration, Environment environment) throws Exception {
+        SpringJobManager springJobManager = new SpringJobManager(context);
+        springJobManager.configure(configuration);
+        environment.lifecycle().manage(springJobManager);
     }
 
 }

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 @OnApplicationStart
 public class ApplicationStartTestJob extends Job {
 
-    static final CountDownLatch latch = new CountDownLatch(1);
+    final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 @OnApplicationStop
 public class ApplicationStopTestJob extends Job {
 
-    static final CountDownLatch latch = new CountDownLatch(1);
+    final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/DependencyTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/DependencyTestJob.java
@@ -8,10 +8,13 @@ import java.util.concurrent.CountDownLatch;
 @Every("100ms")
 public class DependencyTestJob extends Job {
 
-    @Inject
     private Dependency dependency;
+    final CountDownLatch latch = new CountDownLatch(5);
 
-    static final CountDownLatch latch = new CountDownLatch(5);
+    @Inject
+    public DependencyTestJob(Dependency dependency) {
+        this.dependency = dependency;
+    }
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 @Every("50ms")
 public class EveryTestJob extends Job {
 
-    static final CountDownLatch latch = new CountDownLatch(5);
+    final CountDownLatch latch = new CountDownLatch(5);
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CountDownLatch;
 @On("0/1 * * * * ?")
 public class OnTestJob extends Job {
 
-    static final CountDownLatch latch = new CountDownLatch(2);
+    final CountDownLatch latch = new CountDownLatch(2);
 
     @Override
     public void doJob() {

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/SpringJobManagerTest.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/SpringJobManagerTest.java
@@ -1,14 +1,13 @@
 package de.spinscale.dropwizard.jobs;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class SpringJobManagerTest {
 
@@ -17,25 +16,16 @@ public class SpringJobManagerTest {
             Dependency.class);
     private final JobManager jobManager = new SpringJobManager(context);
 
-    @Before
-    public void ensureLatchesAreZero() {
-        assertThat(ApplicationStartTestJob.latch.getCount(), is(1L));
-        assertThat(OnTestJob.latch.getCount(), is(2L));
-        assertThat(EveryTestJob.latch.getCount(), is(5L));
-        assertThat(DependencyTestJob.latch.getCount(), is(5L));
-        assertThat(ApplicationStopTestJob.latch.getCount(), is(1L));
-    }
-
     @Test
     public void testThatJobsAreExecuted() throws Exception {
         jobManager.start();
-        assertThat(ApplicationStartTestJob.latch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(context.getBean(ApplicationStartTestJob.class).latch.await(1, TimeUnit.SECONDS), is(true));
 
-        assertThat(OnTestJob.latch.await(2, TimeUnit.SECONDS), is(true));
-        assertThat(DependencyTestJob.latch.await(2, TimeUnit.SECONDS), is(true));
-        assertThat(EveryTestJob.latch.await(2, TimeUnit.SECONDS), is(true));
+        assertThat(context.getBean(OnTestJob.class).latch.await(2, TimeUnit.SECONDS), is(true));
+        assertThat(context.getBean(DependencyTestJob.class).latch.await(2, TimeUnit.SECONDS), is(true));
+        assertThat(context.getBean(EveryTestJob.class).latch.await(2, TimeUnit.SECONDS), is(true));
 
         jobManager.stop();
-        assertThat(ApplicationStopTestJob.latch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(context.getBean(ApplicationStopTestJob.class).latch.await(1, TimeUnit.SECONDS), is(true));
     }
 }

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/SpringJobsBundleTest.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/SpringJobsBundleTest.java
@@ -1,18 +1,19 @@
 package de.spinscale.dropwizard.jobs;
 
+import io.dropwizard.Configuration;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import io.dropwizard.setup.Environment;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
-import io.dropwizard.setup.Environment;
-
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class SpringJobsBundleTest {
 
@@ -20,12 +21,12 @@ public class SpringJobsBundleTest {
     private final LifecycleEnvironment applicationContext = mock(LifecycleEnvironment.class);
 
     @Test
-    public void assertJobsBundleIsWorking() {
+    public void assertJobsBundleIsWorking() throws Exception {
         ApplicationContext context = new AnnotationConfigApplicationContext(ApplicationStartTestJob.class,
                 ApplicationStopTestJob.class, EveryTestJob.class, OnTestJob.class);
 
         when(environment.lifecycle()).thenReturn(applicationContext);
-        new SpringJobsBundle(context).run(environment);
+        new SpringJobsBundle(context).run(new MyConfiguration(), environment);
 
         final ArgumentCaptor<JobManager> jobManagerCaptor = ArgumentCaptor.forClass(JobManager.class);
         verify(applicationContext).manage(jobManagerCaptor.capture());
@@ -33,4 +34,6 @@ public class SpringJobsBundleTest {
         JobManager jobManager = jobManagerCaptor.getValue();
         assertThat(jobManager, is(notNullValue()));
     }
+
+    private static class MyConfiguration extends Configuration implements JobConfiguration {}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>de.spinscale</groupId>
+	<groupId>de.spinscale.dropwizard</groupId>
 	<artifactId>dropwizard-jobs</artifactId>
-	<version>1.1.5-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>dropwizard-jobs</name>
@@ -11,19 +11,12 @@
 
 	<description>https://github.com/spinscale/dropwizard-jobs</description>
 
-	<parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<dropwizard.version>1.0.2</dropwizard.version>
 		<spring.version>4.3.3.RELEASE</spring.version>
 		<guice.version>4.1.0</guice.version>
 		<quartz.version>2.2.3</quartz.version>
-    	<java.version>1.7</java.version>
 	</properties>
 
 	<developers>
@@ -104,11 +97,6 @@
 			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz</artifactId>
 			<version>${quartz.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.reflections</groupId>
-			<artifactId>reflections</artifactId>
-			<version>0.9.10</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>


### PR DESCRIPTION
- The `groupId` has been renamed to `de.spinscale.dropwizard`
- Removed any reflection based code in the code base, along with the reflections library
- The above also means, every job has to be added manually to the JobsBundle - no more autodetection
- The above also means, that wiring for guice/spring has to happen - constructor injection is encouraged now
- Allowed jobs to have arbitrary constructors

Because of all the changes, I also would like this to be version 2.0.0 (think semver)...

I'd like to discuss first, if the above makes sense.. I think there can be even more cleanups and refactorings.. the code base could be much nicer!
