### PR TITLE
expose quartz scheduler via bundles

### DIFF
--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
@@ -65,6 +65,10 @@ public class JobManager implements Managed {
         scheduler.shutdown(true);
     }
 
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
     protected JobFactory getJobFactory() {
         return new DropwizardJobFactory(jobs);
     }

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobsBundle.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobsBundle.java
@@ -1,6 +1,9 @@
 package de.spinscale.dropwizard.jobs;
 
 import com.codahale.metrics.SharedMetricRegistries;
+
+import org.quartz.Scheduler;
+
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -8,6 +11,7 @@ import io.dropwizard.setup.Environment;
 public class JobsBundle implements ConfiguredBundle<JobConfiguration> {
 
     private final Job[] jobs;
+    protected JobManager jobManager;
 
     public JobsBundle(Job ... jobs) {
         this.jobs = jobs;
@@ -15,7 +19,7 @@ public class JobsBundle implements ConfiguredBundle<JobConfiguration> {
 
     @Override
     public void run(JobConfiguration configuration, Environment environment) throws Exception {
-        JobManager jobManager = new JobManager(jobs);
+        jobManager = new JobManager(jobs);
         jobManager.configure(configuration);
         environment.lifecycle().manage(jobManager);
     }
@@ -26,4 +30,9 @@ public class JobsBundle implements ConfiguredBundle<JobConfiguration> {
         // has been removed
         SharedMetricRegistries.add(Job.DROPWIZARD_JOBS_KEY, bootstrap.getMetricRegistry());
     }
+
+    public Scheduler getScheduler() {
+        return jobManager.getScheduler();
+    }
+
 }

--- a/dropwizard-jobs-guice/src/main/java/de/spinscale/dropwizard/jobs/GuiceJobsBundle.java
+++ b/dropwizard-jobs-guice/src/main/java/de/spinscale/dropwizard/jobs/GuiceJobsBundle.java
@@ -1,19 +1,19 @@
 package de.spinscale.dropwizard.jobs;
 
 import com.google.inject.Injector;
+
 import io.dropwizard.setup.Environment;
 
 public class GuiceJobsBundle extends JobsBundle {
 
-    private GuiceJobManager guiceJobsManager;
-    
     public GuiceJobsBundle(Injector injector) {
-        guiceJobsManager = new GuiceJobManager(injector);
+        jobManager = new GuiceJobManager(injector);
     }
 
     @Override
     public void run(JobConfiguration configuration, Environment environment) throws Exception {
-        guiceJobsManager.configure(configuration);
-        environment.lifecycle().manage(guiceJobsManager);
+        jobManager.configure(configuration);
+        environment.lifecycle().manage(jobManager);
     }
+
 }

--- a/dropwizard-jobs-spring/src/main/java/de/spinscale/dropwizard/jobs/SpringJobsBundle.java
+++ b/dropwizard-jobs-spring/src/main/java/de/spinscale/dropwizard/jobs/SpringJobsBundle.java
@@ -1,7 +1,8 @@
 package de.spinscale.dropwizard.jobs;
 
-import io.dropwizard.setup.Environment;
 import org.springframework.context.ApplicationContext;
+
+import io.dropwizard.setup.Environment;
 
 public class SpringJobsBundle extends JobsBundle {
 
@@ -13,9 +14,9 @@ public class SpringJobsBundle extends JobsBundle {
 
     @Override
     public void run(JobConfiguration configuration, Environment environment) throws Exception {
-        SpringJobManager springJobManager = new SpringJobManager(context);
-        springJobManager.configure(configuration);
-        environment.lifecycle().manage(springJobManager);
+        jobManager = new SpringJobManager(context);
+        jobManager.configure(configuration);
+        environment.lifecycle().manage(jobManager);
     }
 
 }


### PR DESCRIPTION
This allows the application access to the quartz scheduler object via the bundles to use during run time. An example use case would be to create an admin task to pause/resume all jobs. The bundle could be passed into the task and then it would simply call `scheduler.pauseAll()` or `scheduler.resumeAll()`.

I'm not sure if this is the best way to do this - I'm open to suggestions.