### PR TITLE
pass in the job context

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,31 @@ Add to your pom:
 <dependency>
   <groupId>de.spinscale.dropwizard</groupId>
   <artifactId>dropwizard-jobs-core</artifactId>
-  <version>2.0.1</version>
+  <version>3.0.0</version>
 </dependency>
 ```
+
+## API changes from 3.x
+The 3.x release has breaking API changes that would need to be addressed if upgrading from an older version. The
+signature of the <code>doJob()</code> method has changed and now takes a <code>JobExecutionContext</code> as an
+argument and also throws a <code>JobExecutionException</code>.
+
+##### 3.x
+```java
+  @Override
+  public void doJob(JobExecutionContext context) throws JobExecutionException {
+    ...
+  }
+```
+
+##### < 3.x
+```java
+  @Override
+  public void doJob() {
+    ...
+  }
+```
+
 
 ## Installing the bundle from source code
 
@@ -68,7 +90,7 @@ The <code>@OnApplicationStart</code> annotation triggers a job after the quartz 
 @OnApplicationStart
 public class StartupJob extends Job {
   @Override
-  public void doJob() {
+  public void doJob(JobExecutionContext context) throws JobExecutionException {
     // logic run once on application start
   }
 }
@@ -80,7 +102,7 @@ The <code>@OnApplicationStop</code> annotation triggers a job when the applicati
 @OnApplicationStop
 public class StopJob extends Job {
   @Override
-  public void doJob() {
+  public void doJob(JobExecutionContext context) throws JobExecutionException {
     // logic run once on application stop
   }
 }
@@ -93,7 +115,7 @@ Use in conjunction with <code>@DelayStart</code> to delay the first invocation o
 @Every("1s")
 public class EveryTestJob extends Job {
   @Override
-  public void doJob() {
+  public void doJob(JobExecutionContext context) throws JobExecutionException {
     // logic run every time and time again
   }
 }
@@ -106,7 +128,7 @@ The <code>@DelayStart</code> annotation can be used in conjunction with @Every t
 @Every("1s")
 public class EveryTestJobWithDelayedStart extends Job {
   @Override
-  public void doJob() {
+  public void doJob(JobExecutionContext context) throws JobExecutionException {
     // logic run every time and time again
   }
 }
@@ -119,9 +141,8 @@ This expression allows you to run a job every 15 seconds and could possibly also
 ```java
 @On("0/15 * * * * ?")
 public class OnTestJob extends Job {
-
   @Override
-  public void doJob() {
+  public void doJob(JobExecutionContext context) throws JobExecutionException {
     // logic run via cron expression
   }
 }
@@ -167,9 +188,8 @@ package com.my.awesome.web.app
  */
 @Every(value="5s", jobName="MyJob")
 public class MyJob extends Job {
-
   @Override
-  public void doJob() {
+  public void doJob(JobExecutionContext context) throws JobExecutionException {
     // do some work here
   } 
 }
@@ -266,4 +286,5 @@ public class ApplicationConfiguration extends Configuration implements JobConfig
  * [Yun Zhi Lin](https://github.com/yunspace)
  * [Eyal Golan](https://github.com/eyalgo)
  * [Jonathan Fritz](https://github.com/MusikPolice)
+ * [Ahsan Rabbani](https://github.com/xargsgrep)
 

--- a/dropwizard-jobs-core/pom.xml
+++ b/dropwizard-jobs-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>2.0.2-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dropwizard-jobs-core</artifactId>

--- a/dropwizard-jobs-core/pom.xml
+++ b/dropwizard-jobs-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
 
     <artifactId>dropwizard-jobs-core</artifactId>

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/Job.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/Job.java
@@ -15,6 +15,7 @@ public abstract class Job implements org.quartz.Job {
     public static final String DROPWIZARD_JOBS_KEY = "dropwizard-jobs";
 
     private final Timer timer;
+    private final MetricRegistry metricRegistry;
 
     public Job() {
         // get the metrics registry which was shared during bundle instantiation
@@ -22,15 +23,21 @@ public abstract class Job implements org.quartz.Job {
     }
 
     public Job(MetricRegistry metricRegistry) {
-        timer = metricRegistry.timer(name(getClass()));
+        this.timer = metricRegistry.timer(name(getClass()));
+        this.metricRegistry = metricRegistry;
     }
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         try (Context timerContext = timer.time()) {
-            doJob();
+            doJob(context);
         }
     }
 
-    public abstract void doJob();
+    public abstract void doJob(JobExecutionContext context) throws JobExecutionException;
+
+    protected MetricRegistry getMetricRegistry() {
+        return metricRegistry;
+    }
+
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/AbstractJob.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/AbstractJob.java
@@ -1,5 +1,8 @@
 package de.spinscale.dropwizard.jobs;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 public abstract class AbstractJob extends Job {
@@ -11,7 +14,7 @@ public abstract class AbstractJob extends Job {
     }
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.OnApplicationStop;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 @OnApplicationStop
 public class ApplicationStopTestJob extends AbstractJob {
 
@@ -10,7 +13,7 @@ public class ApplicationStopTestJob extends AbstractJob {
     }
 
     @Override
-    public void doJob() {
-        super.doJob();
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
+        super.doJob(context);
     }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobWithSameJobName.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJobWithSameJobName.java
@@ -7,6 +7,9 @@ import com.google.common.collect.Lists;
 
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 // this job has the same job name as EveryTestJobWithJobName. Only one will be created
 @Every(value = "1s", jobName = "FooJob")
 public class EveryTestJobWithSameJobName extends Job {
@@ -14,7 +17,7 @@ public class EveryTestJobWithSameJobName extends Job {
     public static List<String> results = Lists.newArrayList();
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         results.add(new Date().toString());
     }
 }

--- a/dropwizard-jobs-guice/README.md
+++ b/dropwizard-jobs-guice/README.md
@@ -13,7 +13,7 @@ Add to your pom:
 <dependency>
   <groupId>de.spinscale</groupId>
   <artifactId>dropwizard-jobs-guice</artifactId>
-  <version>1.0.1</version>
+  <version>3.0.0</version>
 </dependency>
 ```
 

--- a/dropwizard-jobs-guice/pom.xml
+++ b/dropwizard-jobs-guice/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
 
     <artifactId>dropwizard-jobs-guice</artifactId>

--- a/dropwizard-jobs-guice/pom.xml
+++ b/dropwizard-jobs-guice/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>2.0.2-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dropwizard-jobs-guice</artifactId>

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.OnApplicationStart;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @OnApplicationStart
@@ -10,7 +13,7 @@ public class ApplicationStartTestJob extends Job {
     final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 }

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.OnApplicationStop;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @OnApplicationStop
@@ -10,7 +13,7 @@ public class ApplicationStopTestJob extends Job {
     final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/DependencyTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/DependencyTestJob.java
@@ -3,6 +3,9 @@ package de.spinscale.dropwizard.jobs;
 import com.google.inject.Inject;
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @Every("100ms")
@@ -17,7 +20,7 @@ public class DependencyTestJob extends Job {
     }
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         if (dependency == null)
             throw new IllegalStateException("dependency is null");
         latch.countDown();

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @Every("100ms")
@@ -10,7 +13,7 @@ public class EveryTestJob extends Job {
     final CountDownLatch latch = new CountDownLatch(5);
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 }

--- a/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
+++ b/dropwizard-jobs-guice/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.On;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @On("0/1 * * * * ?")
@@ -10,7 +13,7 @@ public class OnTestJob extends Job {
     final CountDownLatch latch = new CountDownLatch(2);
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 }

--- a/dropwizard-jobs-spring/pom.xml
+++ b/dropwizard-jobs-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
 
     <artifactId>dropwizard-jobs-spring</artifactId>

--- a/dropwizard-jobs-spring/pom.xml
+++ b/dropwizard-jobs-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.spinscale.dropwizard</groupId>
         <artifactId>dropwizard-jobs</artifactId>
-        <version>2.0.2-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dropwizard-jobs-spring</artifactId>

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStartTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.OnApplicationStart;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @OnApplicationStart
@@ -10,7 +13,7 @@ public class ApplicationStartTestJob extends Job {
     final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 }

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/ApplicationStopTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.OnApplicationStop;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @OnApplicationStop
@@ -10,7 +13,7 @@ public class ApplicationStopTestJob extends Job {
     final CountDownLatch latch = new CountDownLatch(1);
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 }

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/DependencyTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/DependencyTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import javax.inject.Inject;
 import java.util.concurrent.CountDownLatch;
 
@@ -17,7 +20,7 @@ public class DependencyTestJob extends Job {
     }
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         if (dependency == null)
             throw new IllegalStateException("dependency is null");
         latch.countDown();

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/EveryTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.Every;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @Every("50ms")
@@ -10,7 +13,7 @@ public class EveryTestJob extends Job {
     final CountDownLatch latch = new CountDownLatch(5);
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 }

--- a/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
+++ b/dropwizard-jobs-spring/src/test/java/de/spinscale/dropwizard/jobs/OnTestJob.java
@@ -2,6 +2,9 @@ package de.spinscale.dropwizard.jobs;
 
 import de.spinscale.dropwizard.jobs.annotations.On;
 
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
 import java.util.concurrent.CountDownLatch;
 
 @On("0/1 * * * * ?")
@@ -10,7 +13,7 @@ public class OnTestJob extends Job {
     final CountDownLatch latch = new CountDownLatch(2);
 
     @Override
-    public void doJob() {
+    public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>de.spinscale.dropwizard</groupId>
     <artifactId>dropwizard-jobs</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <packaging>pom</packaging>
 
     <name>dropwizard-jobs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>de.spinscale.dropwizard</groupId>
     <artifactId>dropwizard-jobs</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>dropwizard-jobs</name>
@@ -66,7 +66,7 @@
         <url>https://github.com/spinscale/dropwizard-jobs</url>
         <connection>scm:git:git@github.com:spinscale/dropwizard-jobs.git</connection>
         <developerConnection>scm:git:git@github.com:spinscale/dropwizard-jobs.git</developerConnection>
-        <tag>dropwizard-jobs-2.0.1</tag>
+        <tag>dropwizard-jobs-3.0.0</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
1. Pass in the JobExecutionContext into doJob so implementing jobs have access to it also.
2. Allow throwing JobExecutionException from doJob so implementing jobs can specify refire upon failures.