### PR TITLE
Add support integrate with HK2

### DIFF
--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/Hk2JobsBundle.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/Hk2JobsBundle.java
@@ -1,0 +1,115 @@
+package de.spinscale.dropwizard.jobs;
+
+import io.dropwizard.setup.Environment;
+import org.glassfish.hk2.api.Filter;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.server.spi.AbstractContainerLifecycleListener;
+import org.glassfish.jersey.server.spi.Container;
+import org.quartz.Scheduler;
+import org.quartz.spi.JobFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link JobsBundle} implementation that uses HK2 to instantiate a {@link Job}.
+ * 
+ * <p>
+ * Example of usage:
+ * </p>
+ * 
+ * <pre>
+ * public class MyDropwizardApplication extends Application<MyConfiguration> {
+ *     ...
+ * 
+ *     &#64;Override
+ *     public void initialize(Bootstrap<MyConfiguration> bootstrap) {
+ *         bootstrap.addBundle(new Hk2JobsBundle(BuilderHelper.createContractFilter(Job.class.getName())));
+ *     }
+ * 
+ *     &#64;Override
+ *     public void run(MyConfiguration configuration, Environment environment) {
+ *         environment.jersey().register(new AbstractBinder() {
+ *             &#64;Override
+ *             protected void configure() {
+ *                 // Register jobs with contract type `de.spinscale.dropwizard.jobs.Job`.
+ *                 bind(MyJobWithPerLookup.class).to(Job.class);
+ *                 bind(MyJobWithPerThread.class).to(Job.class).in(PerThread.class);
+ *                 bind(MyJobWithSingleton.class).to(Job.class).in(Singleton.class);
+ *             }
+ *         });
+ *     }
+ * }
+ * </pre>
+ */
+public class Hk2JobsBundle extends JobsBundle {
+
+    private final Filter searchCriteria;
+
+    /**
+     * Create a new instance with given HK2 search criteria.
+     * 
+     * <p>
+     * You can implement your own {@code Filter} or you can use one of the {@code Filter} implementations provided by
+     * {@code BuilderHelper}. The most common case is to use an {@code IndexedFilter} provided by {@code BuilderHelper},
+     * like this:
+     * </p>
+     * 
+     * <pre>
+     * IndexedFilter jobFilter = BuilderHelper.createContractFilter(Job.class.getName());
+     * bootstrap.addBundle(new Hk2JobsBundle(jobFilter));
+     * </pre>
+     * 
+     * @param searchCriteria the returned {@link Job} service will match the Filter (in other words,
+     *            searchCriteria.matches returns true). Should not be null.
+     */
+    public Hk2JobsBundle(final Filter searchCriteria) {
+        Objects.requireNonNull(searchCriteria);
+        this.searchCriteria = searchCriteria;
+    }
+
+    @Override
+    public void run(final JobConfiguration configuration, final Environment environment) {
+        environment.jersey().register(new AbstractContainerLifecycleListener() {
+            @Override
+            public void onStartup(Container container) {
+                final ServiceLocator locator = container.getApplicationHandler().getServiceLocator();
+                // TODO: Avoid useless Job instantiation. Note: Same as GuiceJobManager and SpringJobManager.
+                @SuppressWarnings("unchecked")
+                final List<Job> jobs = (List<Job>) locator.getAllServices(searchCriteria);
+                jobManager = new JobManager(configuration, jobs.toArray(new Job[jobs.size()])) {
+                    @Override
+                    protected JobFactory getJobFactory() {
+                        return (bundle,
+                                scheduler) -> (org.quartz.Job) locator.getAllServiceHandles(searchCriteria).stream()
+                                        .filter(sh -> sh.getActiveDescriptor().getImplementationClass()
+                                                .equals(bundle.getJobDetail().getJobClass()))
+                                        .findFirst().orElseThrow(IllegalStateException::new).getService();
+                    }
+                };
+                try {
+                    jobManager.start();
+                } catch (Exception ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
+
+            @Override
+            public void onShutdown(Container container) {
+                if (jobManager != null) {
+                    try {
+                        jobManager.stop();
+                    } catch (Exception ex) {
+                        throw new IllegalStateException(ex);
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
+    public Scheduler getScheduler() {
+        return (jobManager != null) ? super.getScheduler() : null;
+    }
+
+}

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/Hk2JobsBundleTest.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/Hk2JobsBundleTest.java
@@ -1,0 +1,124 @@
+package de.spinscale.dropwizard.jobs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.setup.Environment;
+import org.glassfish.hk2.api.Filter;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ApplicationHandler;
+import org.glassfish.jersey.server.spi.AbstractContainerLifecycleListener;
+import org.glassfish.jersey.server.spi.Container;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.inject.Singleton;
+
+public class Hk2JobsBundleTest {
+
+    private final JobConfiguration configuration = mock(JobConfiguration.class);
+    private final Environment environment = mock(Environment.class);
+
+    /**
+     * A test case for the {@link Hk2JobsBundle#run(JobConfiguration, Environment)} and
+     * {@link Hk2JobsBundle#getScheduler()}.
+     */
+    @Test
+    public void registerToContainer() throws Exception {
+        final Filter searchCriteria = BuilderHelper.createContractFilter(Job.class.getName());
+        final Hk2JobsBundle instance = new Hk2JobsBundle(searchCriteria);
+
+        // initialization
+        final DropwizardResourceConfig resourceConfig = DropwizardResourceConfig.forTesting(new MetricRegistry());
+        when(environment.jersey()).thenReturn(new JerseyEnvironment(null, resourceConfig));
+        instance.run(configuration, environment);
+        resourceConfig.register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(ApplicationStartTestJob.class).to(Job.class).in(Singleton.class);
+                bind(ApplicationStopTestJob.class).to(Job.class).in(Singleton.class);
+                bind(EveryTestJob.class).to(EveryTestJob.class);
+            }
+        });
+        final ApplicationHandler applicationHandler = new ApplicationHandler(resourceConfig);
+        final ServiceLocator serviceLocator = applicationHandler.getServiceLocator();
+        final Container container = mock(Container.class);
+        when(container.getApplicationHandler()).thenReturn(applicationHandler);
+        when(container.getConfiguration()).thenReturn(resourceConfig);
+
+        // verify precondition
+        assertThat(instance.getScheduler()).isNull();
+
+        // startup container
+        applicationHandler.onStartup(container);
+        Thread.sleep(1000);
+
+        // verify at startup
+        @SuppressWarnings("unchecked")
+        final List<AbstractJob> jobs = (List<AbstractJob>) serviceLocator.getAllServices(searchCriteria);
+        AbstractJob applicationStartTestJob = getJob(jobs, ApplicationStartTestJob.class);
+        AbstractJob applicationStopTestJob = getJob(jobs, ApplicationStopTestJob.class);
+        assertThat(jobs).hasSize(2);
+        assertThat(applicationStartTestJob.latch().getCount()).isEqualTo(0);
+        assertThat(applicationStopTestJob.latch().getCount()).isEqualTo(1);
+        assertThat(instance.getScheduler().isStarted()).isTrue();
+
+        // shutdown container
+        applicationHandler.onShutdown(container);
+        Thread.sleep(1000);
+
+        // verify at shutdown
+        assertThat(applicationStopTestJob.latch().getCount()).isEqualTo(0);
+        assertThat(instance.getScheduler().isShutdown()).isTrue();
+    }
+
+    /**
+     * A test case for the {@link JobManager#start()} and {@link JobManager#stop()} that raise exception.
+     */
+    @Test
+    public void testIllegalState() {
+        final AtomicReference<AbstractContainerLifecycleListener> listener = new AtomicReference<>();
+        final JerseyEnvironment jersey = mock(JerseyEnvironment.class);
+        when(environment.jersey()).thenReturn(jersey);
+        doAnswer(invocation -> {
+            listener.set(invocation.getArgument(0));
+            return null;
+        }).when(jersey).register((Object) any());
+
+        final Hk2JobsBundle instance = new Hk2JobsBundle(BuilderHelper.createContractFilter(""));
+        instance.run(null, environment);
+
+        final Container container = mock(Container.class);
+        final ApplicationHandler applicationHandler = new ApplicationHandler();
+        when(container.getApplicationHandler()).thenReturn(applicationHandler);
+        try {
+            listener.get().onStartup(container);
+            fail();
+        } catch (IllegalStateException ignore) {
+            // OK: fall through
+        }
+        try {
+            listener.get().onShutdown(container);
+            fail();
+        } catch (IllegalStateException ignore) {
+            // OK: fall through
+        }
+    }
+
+    private AbstractJob getJob(final List<AbstractJob> jobs, final Class<?> implementationClass) {
+        return jobs.stream().filter(job -> job.getClass().equals(implementationClass)).findFirst()
+                .orElseThrow(IllegalStateException::new);
+    }
+
+}


### PR DESCRIPTION
As a Dependency Injection framework, Dropwizard officially supports HK2.
For simple cases, it is preferable to use HK2 rather than Guice or Spring.

Ref: https://github.com/dropwizard/dropwizard/issues/1626