### PR TITLE
Allow jobs marked with @On to also be configurable

### DIFF
--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
@@ -102,6 +102,11 @@ public class JobManager implements Managed {
         for (Class<? extends org.quartz.Job> clazz : onJobClasses) {
             On onAnnotation = clazz.getAnnotation(On.class);
             String cron = onAnnotation.value();
+            if(cron.isEmpty() || cron.matches("\\$\\{.*\\}")) {
+                cron = this.readDurationFromConfig(onAnnotation, clazz);
+                log.info(clazz + " is configured in the config file to run every " + cron);
+            }
+            
             String key = StringUtils.isNotBlank(onAnnotation.jobName()) ? onAnnotation.jobName() : clazz.getCanonicalName();
             int priority = onAnnotation.priority();
             On.MisfirePolicy misfirePolicy = onAnnotation.misfirePolicy();
@@ -206,6 +211,18 @@ public class JobManager implements Managed {
             property = annotation.value().substring(2, annotation.value().length() - 1);
         }
         return configuration.getJobs().getOrDefault(property, null);
+    }
+    
+    private String readDurationFromConfig(On annotation, Class<? extends org.quartz.Job> clazz) {
+        if(this.configuration == null) {
+            return null;
+        } else {
+            String property = WordUtils.uncapitalize(clazz.getSimpleName());
+            if(!annotation.value().isEmpty()) {
+                property = annotation.value().substring(2, annotation.value().length() - 1);
+            }
+            return (String)this.configuration.getJobs().getOrDefault(property,  null);
+        }
     }
 
     protected void scheduleAllJobsOnApplicationStart() throws SchedulerException {


### PR DESCRIPTION
Only the @Every annotation allows to use placeholders for values declared in the aplication configuration.
The crons supported by the @On annotation can easily benefit from the same possibility.
This commit simply shadows the same config-reading flow already present for @Every.