### PR TITLE
Allow jobs marked with @On to also be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ As of 1.0.2, the period for @Every jobs can be read from the dropwizard config f
 jobs:
   myJob: 10s
   myOtherJob: 20s
+  cronJob: "0 0/3 0 ? * * *"
 ```
   
 Where MyJob and MyOtherJob are the names of Job classes in the application. In the <code>Configuration</code> class add the corresponding property:
@@ -235,6 +236,15 @@ An alternative label to the class name can also be specified:
 
 ```java
 @Every("${foobar}")
+public class MyJob extends Job {
+    ...
+}
+```
+The same can be done with the <code>@On</code> annotation as well, as second option to cron-base jobs configuration
+An alternative label to the class name can also be specified:
+
+```java
+@On("${cronJob}")
 public class MyJob extends Job {
     ...
 }

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/annotations/On.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/annotations/On.java
@@ -18,7 +18,7 @@ public @interface On {
         FIRE_AND_PROCEED
     }
 
-    String value();
+    String value() default "";
 
     /**
      * The name of this job. If not specified, the name of the job will default to the canonical name of the annotated


### PR DESCRIPTION
(this tries to fix a previous PR attempt)

Only the `@Every` annotation allows to use placeholders for values declared in the application configuration.
The crons supported by the `@On` annotation can easily benefit from the same possibility.
This commit simply shadows the same config-reading flow already present for `@every`.