### PR TITLE
TimeZone support for @On annotations

### DIFF
--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
@@ -106,7 +106,6 @@ public class JobManager implements Managed {
             String timeZoneStr = onAnnotation.timeZone();
             TimeZone timeZone = StringUtils.isNotBlank(timeZoneStr) ? TimeZone.getTimeZone(ZoneId.of(timeZoneStr)) : TimeZone.getDefault();
 
-            String key = StringUtils.isNotBlank(onAnnotation.jobName()) ? onAnnotation.jobName() : clazz.getCanonicalName();
             int priority = onAnnotation.priority();
             On.MisfirePolicy misfirePolicy = onAnnotation.misfirePolicy();
             boolean requestRecovery = onAnnotation.requestRecovery();

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/JobManager.java
@@ -7,23 +7,17 @@ import de.spinscale.dropwizard.jobs.annotations.OnApplicationStart;
 import de.spinscale.dropwizard.jobs.annotations.OnApplicationStop;
 import de.spinscale.dropwizard.jobs.parser.TimeParserUtil;
 import io.dropwizard.lifecycle.Managed;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
-import org.quartz.CronScheduleBuilder;
-import org.quartz.JobBuilder;
-import org.quartz.JobDetail;
-import org.quartz.JobKey;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.SimpleScheduleBuilder;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
+import org.quartz.*;
 import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.spi.JobFactory;
 import org.slf4j.Logger;
@@ -109,12 +103,16 @@ public class JobManager implements Managed {
                 log.info(clazz + " is configured in the config file to run every " + cron);
             }
 
+            String timeZoneStr = onAnnotation.timeZone();
+            TimeZone timeZone = StringUtils.isNotBlank(timeZoneStr) ? TimeZone.getTimeZone(ZoneId.of(timeZoneStr)) : TimeZone.getDefault();
+
+            String key = StringUtils.isNotBlank(onAnnotation.jobName()) ? onAnnotation.jobName() : clazz.getCanonicalName();
             int priority = onAnnotation.priority();
             On.MisfirePolicy misfirePolicy = onAnnotation.misfirePolicy();
             boolean requestRecovery = onAnnotation.requestRecovery();
             boolean storeDurably = onAnnotation.storeDurably();
 
-            CronScheduleBuilder scheduleBuilder = CronScheduleBuilder.cronSchedule(cron);
+            CronScheduleBuilder scheduleBuilder = CronScheduleBuilder.cronSchedule(cron).inTimeZone(timeZone);
             if (misfirePolicy == On.MisfirePolicy.IGNORE_MISFIRES)
                 scheduleBuilder.withMisfireHandlingInstructionIgnoreMisfires();
             else if (misfirePolicy == On.MisfirePolicy.DO_NOTHING)

--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/annotations/On.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/annotations/On.java
@@ -1,11 +1,10 @@
 package de.spinscale.dropwizard.jobs.annotations;
 
-import org.quartz.Trigger;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.quartz.Trigger;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -26,6 +25,8 @@ public @interface On {
      * @return the name of the job
      */
     String jobName() default "";
+
+    String timeZone() default "";
 
     boolean requestRecovery() default false;
 

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
@@ -1,14 +1,18 @@
 package de.spinscale.dropwizard.jobs;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import de.spinscale.dropwizard.jobs.annotations.Every;
 import de.spinscale.dropwizard.jobs.annotations.On;
 import io.dropwizard.Configuration;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.hamcrest.Matchers;
@@ -19,6 +23,7 @@ import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.SchedulerConfigException;
 import org.quartz.Trigger;
+import org.quartz.impl.matchers.GroupMatcher;
 
 public class JobManagerTest {
 
@@ -161,6 +166,8 @@ public class JobManagerTest {
         CronTrigger trigger = (CronTrigger) jobManager.scheduler.getTriggersOfJob(JobKey.jobKey(jobName)).get(0);
 
         assertEquals("Europe/Stockholm", trigger.getTimeZone().getID());
+
+        jobManager.stop();
     }
 
     @Test
@@ -249,6 +256,20 @@ public class JobManagerTest {
     @On("0/1 * * * * ?")
     class OnTestJobWithDefaultConfiguration extends AbstractJob {
         public OnTestJobWithDefaultConfiguration() {
+            super(1);
+        }
+    }
+
+    @On("0/1 * * * * ?")
+    class OnTestJobWithVariableGroupName extends AbstractJob {
+        public OnTestJobWithVariableGroupName(String groupName) {
+            super(1, groupName);
+        }
+    }
+
+    @On(value = "0 0 13 ? * MON", timeZone = "Europe/Stockholm")
+    class OnTestJobWithTimeZoneConfiguration extends AbstractJob {
+        public OnTestJobWithTimeZoneConfiguration() {
             super(1);
         }
     }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
@@ -1,28 +1,24 @@
 package de.spinscale.dropwizard.jobs;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import de.spinscale.dropwizard.jobs.annotations.Every;
 import de.spinscale.dropwizard.jobs.annotations.On;
 import io.dropwizard.Configuration;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
+import org.quartz.CronTrigger;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.SchedulerConfigException;
 import org.quartz.Trigger;
-import org.quartz.impl.matchers.GroupMatcher;
 
 public class JobManagerTest {
 
@@ -156,6 +152,18 @@ public class JobManagerTest {
     }
 
     @Test
+    public void testJobsWithTimeZoneInOnAnnotation() throws Exception {
+        jobManager = new JobManager(new TestConfig(), new OnTestJobWithTimeZoneConfiguration(),
+            new OnTestJobWithDefaultConfiguration());
+        jobManager.start();
+
+        String jobName = OnTestJobWithTimeZoneConfiguration.class.getCanonicalName();
+        CronTrigger trigger = (CronTrigger) jobManager.scheduler.getTriggersOfJob(JobKey.jobKey(jobName)).get(0);
+
+        assertEquals("Europe/Stockholm", trigger.getTimeZone().getID());
+    }
+
+    @Test
     public void testJobsWithNonDefaultConfiguration() throws Exception {
         jobManager = new JobManager(new TestConfig(), new EveryTestJobWithNonDefaultConfiguration(),
                 new OnTestJobWithNonDefaultConfiguration());
@@ -242,13 +250,6 @@ public class JobManagerTest {
     class OnTestJobWithDefaultConfiguration extends AbstractJob {
         public OnTestJobWithDefaultConfiguration() {
             super(1);
-        }
-    }
-
-    @On("0/1 * * * * ?")
-    class OnTestJobWithVariableGroupName extends AbstractJob {
-        public OnTestJobWithVariableGroupName(String groupName) {
-            super(1, groupName);
         }
     }
 


### PR DESCRIPTION
Similar to #65 this introduces the option of having timezone added to
the `@On`-annotation. It does _not_ however add the option of doing so in the
configration.

The annotation is used in the following way in order to specify when to
be executed on Mondays at 1pm Stockholm time.
```java
@On(value = "0 0 13 ? * MON", timeZone = "Europe/Stockholm")
```

This is especially useful when you want to make sure the job is only
executed on certain days regardsless of where your server or local
machine is running.

Default timezone will be system default.