### PR TITLE
Allow usage of groupName in order to reuse class

### DIFF
--- a/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/Job.java
+++ b/dropwizard-jobs-core/src/main/java/de/spinscale/dropwizard/jobs/Job.java
@@ -1,30 +1,39 @@
 package de.spinscale.dropwizard.jobs;
 
+import static com.codahale.metrics.MetricRegistry.name;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Timer.Context;
-
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-
-import static com.codahale.metrics.MetricRegistry.name;
 
 public abstract class Job implements org.quartz.Job {
 
     public static final String DROPWIZARD_JOBS_KEY = "dropwizard-jobs";
+    private final String groupName;
 
     private final Timer timer;
     private final MetricRegistry metricRegistry;
 
     public Job() {
         // get the metrics registry which was shared during bundle instantiation
-        this(SharedMetricRegistries.getOrCreate(DROPWIZARD_JOBS_KEY));
+        this(SharedMetricRegistries.getOrCreate(DROPWIZARD_JOBS_KEY), null);
+    }
+
+    public Job(String groupName) {
+        this(SharedMetricRegistries.getOrCreate(DROPWIZARD_JOBS_KEY), groupName);
     }
 
     public Job(MetricRegistry metricRegistry) {
+        this(metricRegistry, null);
+    }
+
+    public Job(MetricRegistry metricRegistry, String groupName) {
         this.timer = metricRegistry.timer(name(getClass()));
         this.metricRegistry = metricRegistry;
+        this.groupName = groupName;
     }
 
     @Override
@@ -40,4 +49,7 @@ public abstract class Job implements org.quartz.Job {
         return metricRegistry;
     }
 
+    public String getGroupName() {
+        return groupName;
+    }
 }

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/AbstractJob.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/AbstractJob.java
@@ -13,6 +13,11 @@ public abstract class AbstractJob extends Job {
         latch = new CountDownLatch(count);
     }
 
+    public AbstractJob(int count, String groupName) {
+        super(groupName);
+        latch = new CountDownLatch(count);
+    }
+
     @Override
     public void doJob(JobExecutionContext context) throws JobExecutionException {
         latch.countDown();

--- a/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
+++ b/dropwizard-jobs-core/src/test/java/de/spinscale/dropwizard/jobs/JobManagerTest.java
@@ -1,8 +1,20 @@
 package de.spinscale.dropwizard.jobs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import de.spinscale.dropwizard.jobs.annotations.Every;
 import de.spinscale.dropwizard.jobs.annotations.On;
-
+import io.dropwizard.Configuration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.Test;
@@ -10,16 +22,7 @@ import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.SchedulerConfigException;
 import org.quartz.Trigger;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import io.dropwizard.Configuration;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import org.quartz.impl.matchers.GroupMatcher;
 
 public class JobManagerTest {
 
@@ -103,6 +106,51 @@ public class JobManagerTest {
         assertEquals(false, jobDetail.isDurable());
         assertEquals(Trigger.DEFAULT_PRIORITY, trigger.getPriority());
         assertEquals(Trigger.MISFIRE_INSTRUCTION_SMART_POLICY, trigger.getMisfireInstruction());
+
+        jobManager.stop();
+    }
+
+    @Test
+    public void testJobsWithMultipleInstances() throws Exception {
+        jobManager = new JobManager(
+            new TestConfig(),
+            new OnTestJobWithVariableGroupName("group_one"),
+            new OnTestJobWithVariableGroupName("group_two"),
+            new EveryTestJobWithDefaultConfiguration()
+        );
+
+        jobManager.start();
+        List<String> jobGroupNames = jobManager.scheduler.getJobGroupNames();
+
+        String jobName = EveryTestJobWithDefaultConfiguration.class.getCanonicalName();
+        JobDetail jobDetail = jobManager.scheduler.getJobDetail(JobKey.jobKey(jobName));
+        Trigger trigger = jobManager.scheduler.getTriggersOfJob(JobKey.jobKey(jobName)).get(0);
+
+        assertNotNull(jobDetail);
+        assertNotNull(trigger);
+        assertTrue(jobGroupNames.containsAll(Arrays.asList("group_one", "group_two")));
+        assertThat(jobManager.scheduler.getJobKeys(GroupMatcher.anyGroup()).size(), equalTo(3));
+
+        jobManager.stop();
+    }
+
+    @Test
+    public void testJobsWithoutGroupShouldOnlyHaveOneInstance() throws Exception {
+        jobManager = new JobManager(
+            new TestConfig(),
+            new EveryTestJobWithDefaultConfiguration(),
+            new EveryTestJobWithDefaultConfiguration()
+        );
+
+        jobManager.start();
+
+        String jobName = EveryTestJobWithDefaultConfiguration.class.getCanonicalName();
+        JobDetail jobDetail = jobManager.scheduler.getJobDetail(JobKey.jobKey(jobName));
+        Trigger trigger = jobManager.scheduler.getTriggersOfJob(JobKey.jobKey(jobName)).get(0);
+
+        assertNotNull(jobDetail);
+        assertNotNull(trigger);
+        assertThat(jobManager.scheduler.getJobKeys(GroupMatcher.anyGroup()).size(), equalTo(1));
 
         jobManager.stop();
     }
@@ -194,6 +242,13 @@ public class JobManagerTest {
     class OnTestJobWithDefaultConfiguration extends AbstractJob {
         public OnTestJobWithDefaultConfiguration() {
             super(1);
+        }
+    }
+
+    @On("0/1 * * * * ?")
+    class OnTestJobWithVariableGroupName extends AbstractJob {
+        public OnTestJobWithVariableGroupName(String groupName) {
+            super(1, groupName);
         }
     }
 


### PR DESCRIPTION
It is currently not possible to schedule two different instances of the
same class to run as a scheduled job. That limitation restricts us from
reusing a class since it can only be scheduled once.

This PR enables the possibility to schedule two or more instances of the
same class as long as they have different _group names_ set. It's
backwards compatible and will the current functionality is unchanged
unless a groupname is explicitly set.

[Link to Quartz tutorial](http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-02.html)

**Example usage**
```java
public class GroupNameJob extends Job {

  public StartupJob(String groupName) {
    super(groupName);
  }

  @Override
  public void doJob(JobExecutionContext context) throws JobExecutionException {
  }
}
```
After this the jobs can be registered as usual.